### PR TITLE
Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: android
+android:
+  components:
+    # Uncomment the lines below if you want to
+    # use the latest revision of Android SDK Tools
+    - platform-tools
+    - tools
+
+    # The BuildTools version used by your project
+    - build-tools-22.0.1
+
+    # The SDK version used to compile your project
+    - android-22
+
+    # Additional components
+    # - extra-google-google_play_services
+    # - extra-google-m2repository
+    - extra-android-m2repository
+
+before_script:
+    - chmod +x gradlew
+
+script: "./gradlew build"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -17,6 +17,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Atelier
 *Every artist needs a place where he can paint in peace and store his tools such as palette and swatches.*
 
-![](https://img.shields.io/github/release/Musenkishi/Atelier.svg?label=JitPack%20Maven)
+![](https://img.shields.io/github/release/Musenkishi/Atelier.svg?label=JitPack%20Maven) [![Build Status](https://travis-ci.org/Musenkishi/Atelier.svg?branch=master)](https://travis-ci.org/Musenkishi/Atelier)
 
 This is a library aiming to simplify the use of Palette, especially in lists such as ListView, GridView, or RecyclerView.
 


### PR DESCRIPTION
Configure the project to build with Travis after each commit. Travis is a great way to assure others that your project is buildable. Plus it is great for alerting you if you have forgotten to commit a file or that you have broken the build in some other way. If you merge the request, you will need to go to travis-ci.org and enable the project, then the status will be accurately reflected. 
